### PR TITLE
Add codiceIPA key to publiccode.yml file

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -27,6 +27,8 @@ description:
     shortDescription: Prodotto per la l'invio delle newsletter esternamente a Plone
 developmentStatus: development
 it:
+  riuso:
+    codiceIPA: r_emiro
   conforme:
     gdpr: true
     lineeGuidaDesign: false


### PR DESCRIPTION
This PR:

*    adds the codiceIPA key to the publiccode.yml file.

Please note that `description/it/longDescription: too short (187), min 500 chars`
Thanks @nzambello 